### PR TITLE
D-ske104/issue3

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,9 @@
-export default {
-  env: { browser: true, es2020: true },
+module.exports = {
+  env: {
+    browser: true,
+    es2020: true,
+    node: true,
+  },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',


### PR DESCRIPTION
理由: ESLint は commonJSらしいので、 type: module を指定している場合は
.eslintrc.js ではなく .eslintrc.cjs にする必要がある

```log
Error [ERR_REQUIRE_ESM]: require() of ES Module /workspaces/ushiro/.eslintrc.js from /workspaces/ushiro/node_modules/@eslint/eslintrc/dist/eslintrc.cjs not supported.
Instead change the require of .eslintrc.js in /workspaces/ushiro/node_modules/@eslint/eslintrc/dist/eslintrc.cjs to a dynamic import() which is available in all CommonJS modules.
```